### PR TITLE
feat(Formatters): Add a spoiler function

### DIFF
--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -147,6 +147,13 @@ export function hyperlink(content: string, url: string | URL, title?: string) {
 }
 
 /**
+ * Wraps the content inside spoiler (hidden text).
+ * @param content The content to wrap.
+ * @returns The formatted content.
+ */
+export function spoiler<C extends string>(content: C): `||${C}||`;
+
+/**
  * Formats the user ID into a user mention.
  * @param userId The user ID to format.
  * @returns The formatted user mention.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a `spoiler` function to text formatters. If it gets accepted, I'll add it to https://github.com/discordjs/discord.js/blob/master/src/util/Formatters.js

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
